### PR TITLE
fix(commit-hook): add missing improvement validator

### DIFF
--- a/validateCommit/conventional/validate.js
+++ b/validateCommit/conventional/validate.js
@@ -14,7 +14,7 @@ const chalk = require('chalk')
 const msgPath = process.env.HUSKY_GIT_PARAMS
 const msg = require('fs').readFileSync(msgPath, 'utf-8').trim()
 
-const commitRE = /^(revert: )?(feat|fix|docs|style|refactor|perf|test|workflow|ci|chore|types|build)(\(.+\))?: .{1,50}/
+const commitRE = /^(revert: )?(feat|fix|docs|style|refactor|perf|test|workflow|improvement|ci|chore|types|build)(\(.+\))?: .{1,50}/
 
 if (!commitRE.test(msg)) {
   console.log()


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Not sure if it's bug or feature, but when creating new commit with `npm run commit` and when picking `improvement` as an answer to `Select the type of change that you're committing:` it will result an error: `ERROR  invalid commit message format.`

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the CONTRIBUTING
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Would be good to allow improvement or remove that option, since it's quite confusing and took some time to figure out why commit message is not passing