### PR TITLE
feat(Prettier): use tabs over spaces and increase line length

### DIFF
--- a/prettier/index.js
+++ b/prettier/index.js
@@ -13,15 +13,16 @@ function task () {
   /**
    * Add prettier file
    */
-  const prettierRc = json('.prettierrc.json')
+  const prettierRc = json('.prettierrc')
   prettierRc.set({
     trailingComma: 'es5',
-    tabWidth: 2,
     semi: false,
     singleQuote: true,
-    useTabs: false,
+    useTabs: true,
+    quoteProps: "consistent",
     bracketSpacing: true,
     arrowParens: 'always',
+    printWidth: 120,
   })
   prettierRc.save()
 


### PR DESCRIPTION
Hey! 👋 

This PR do the following changes.

1. Use **Tabs** over **Spaces**
2. Set to keep consistent the quotation in one object
3. Increase the line width to 120

**Why use Tabs over Spaces?**

There are multiple benefits to use tabs over spaces.

1. Tabs have been created especially to indent stuff, not space
2. Tabs size can be easily customised by the end-user to their needs
3. Tabs is one character, you cannot mess with it (with spaces, you can end up with 1 space or 3 spaces sometimes)
4. Tabs is way more accessible than spaces

- **[Nobody talks about the real reason to use Tabs over Spaces](https://www.reddit.com/r/javascript/comments/c8drjo/nobody_talks_about_the_real_reason_to_use_tabs/)**
- **[Why we should default to Tabs instead of Spaces for an 'accessible first' environment](https://dev.to/alexandersandberg/why-we-should-default-to-tabs-instead-of-spaces-for-an-accessible-first-environment-101f)** 