### PR TITLE
refactor: add *.txt to prettierignore

### DIFF
--- a/prettier/index.js
+++ b/prettier/index.js
@@ -44,6 +44,7 @@ function task () {
   prettierIgnore.add('.eslintrc.json')
   prettierIgnore.add('package.json')
   prettierIgnore.add('*.html')
+  prettierIgnore.add('*.txt')
   prettierIgnore.save()
 
   /**


### PR DESCRIPTION
## Proposed changes

As asked by @RomainLanz  in the PR  adonisjs/auth#150, added the `*.txt` to the `.prettierignore` file.