### PR TITLE
Revert add back lock files to the gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,9 @@ coverage
 build
 docs
 dist
+yarn.lock
 shrinkwrap.yaml
+package-lock.json
 ```
 
 

--- a/gitignore/README.md
+++ b/gitignore/README.md
@@ -15,6 +15,8 @@ coverage
 build
 docs
 dist
+yarn.lock
 shrinkwrap.yaml
+package-lock.json
 ```
 

--- a/gitignore/index.js
+++ b/gitignore/index.js
@@ -30,7 +30,9 @@ function task () {
     '*.log',
     'build',
     'dist',
-    'shrinkwrap.yaml'
+    'yarn.lock',
+    'shrinkwrap.yaml',
+    'package-lock.json'
   ]
 
   debug('.gitignore %o', linesToWrite)


### PR DESCRIPTION
Hey 👋 

We shouldn't keep those file around in our own repositories.

Those create two issues.

1. We are spammed with `Snyk` PR to upgrade package whereas it changes nothing.
2. When publishing a package, the lock file isn't useful anymore. Only the root (the application's one) lock file is used by the package manager. Therefore, we are going to install old version when developing whereas the end user will use another version, that may lead to bug we don't catch.

This reverts commit 433b7182384c4680e3d95e79d02c6341456c2323.