### PR TITLE
fix: use `del-cli` instead of `del` because it does not work under Windows

### DIFF
--- a/package/TsPreset.js
+++ b/package/TsPreset.js
@@ -58,7 +58,7 @@ class TsPreset {
    * @return {void}
    */
   up (pkgFile) {
-    pkgFile.setScript('clean', 'del build')
+    pkgFile.setScript('clean', 'del-cli build')
     pkgFile.setScript('compile', 'npm run lint && npm run clean && tsc')
     pkgFile.setScript('build', 'npm run compile')
     pkgFile.setScript('prepublishOnly', 'npm run build')


### PR DESCRIPTION
Since `del` is already a builtin command on Windows, the `npm run clean` command doesn't work as expected on Windows ( it asks for confirmation every time, which is really annoying 😅 ).

See del-cli readme : https://github.com/sindresorhus/del-cli

This shouldn't change anything for the other platforms, because `del-cli` is an alias : https://github.com/sindresorhus/del-cli/blob/main/package.json#L16

